### PR TITLE
Add: `defaultKey` option and documentation for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ app.get('/media/*', s3Proxy({
   prefix: 'optional_s3_path_prefix',
   accessKeyId: 'aws_access_key_id',
   secretAccessKey: 'aws_secret_access_key',
-  overrideCacheControl: 'max-age=100000'
+  overrideCacheControl: 'max-age=100000',
+  defaultKey: 'index.html'
 }));
 ~~~
 
@@ -50,6 +51,11 @@ Value of the `Cache-Control` header to use if the metadata from the S3 object do
 __`overrideCacheControl`__
 
 Value of the `Cache-Control` header that is applied to the response even if there there is a different value on the S3 object metadata.
+
+__`defaultKey`__
+
+If a call is made to a url ending in `/`, and this option is present its value is used as the s3 key name. For example, you may wish to allow users to access `/index.html` when calling `/` on a route. 
+
 
 ### HTTP Cache Headers
 
@@ -90,7 +96,10 @@ Now images can be declared in views like so:
 ~~~
 
 ### Listing objects
-It's also possible to return a JSON listing of all the keys by making a request ending with a trailing slash. For the sample above, issuing a request to `/media/images/` will return: `['logo.png', 'background.jpg']`.
+It's also possible to return a JSON listing of all the keys by making a request ending with a trailing slash. For the sample above, issuing a request to `/media/images/` will return: `['logo.png', 'background.jpg']`. This is the default behavior when `defaultKey` is false.
+
+### Default Key 
+If you don't need list objects when making requests ending in a trailing slash, you can instead use a default s3 key by setting the parameter `defaultKey` in options. For example, if `defaultKey` is set to `index.html`, calls to urls like `/media` will return to object `/media/index.html`. 
 
 ## License
 Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -57,6 +57,11 @@ module.exports = function(options) {
     // This will get everything in the path following the mountpath
     var s3Key = decodeURIComponent(req.originalUrl.substr(req.baseUrl.length + 1));
 
+    // If the key is empty (this occurs if a request comes in for a url ending in '/'), and there is a defaultKey
+    // option present on options, use the default key
+    // E.g. if someone wants to route '/' to '/index.html'
+    if ( s3Key === '' && options.defaultKey ) s3Key = options.defaultKey;
+
     // Chop off the querystring, it causes problems with SDK.
     var queryIndex = s3Key.indexOf('?');
     if (queryIndex !== -1) {
@@ -154,7 +159,10 @@ module.exports = function(options) {
   return function(req, res, next) {
     if (req.method !== 'GET') return next();
 
-    if (req.path.slice(-1) === '/') {
+    //If a request is made to a url ending in '/', but there isn't a default file name,
+    // return a list of s3 keys. Otherwise, let the getObject() method handle the request
+    // E.g. if someone wants to route '/' to '/index.html' they should be able to bypass listKeys()
+    if (!options.defaultKey && req.path.slice(-1) === '/') {
       listKeys(req, res, next);
     } else {
       getObject(req, res, next);


### PR DESCRIPTION
Allows consumers of this library to host index.html by setting a defaultKey option. This overrides the listKeys function but is disabled by default.