### PR TITLE
Fix for "s3 key with url like `/?foo=bar` with query on `/` path, leads to error when reading .createReadStream()"

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -57,16 +57,16 @@ module.exports = function(options) {
     // This will get everything in the path following the mountpath
     var s3Key = decodeURIComponent(req.originalUrl.substr(req.baseUrl.length + 1));
 
-    // If the key is empty (this occurs if a request comes in for a url ending in '/'), and there is a defaultKey
-    // option present on options, use the default key
-    // E.g. if someone wants to route '/' to '/index.html'
-    if ( s3Key === '' && options.defaultKey ) s3Key = options.defaultKey;
-
     // Chop off the querystring, it causes problems with SDK.
     var queryIndex = s3Key.indexOf('?');
     if (queryIndex !== -1) {
       s3Key = s3Key.substr(0, queryIndex);
     }
+
+    // If the key is empty (this occurs if a request comes in for a url ending in '/'), and there is a defaultKey
+    // option present on options, use the default key
+    // E.g. if someone wants to route '/' to '/index.html'
+    if ( s3Key === '' && options.defaultKey ) s3Key = options.defaultKey;
 
     // Strip out any path segments that start with a double dash '--'. This is just used
     // to force a cache invalidation.


### PR DESCRIPTION
If I have a defaultKey such as index.html, and I request a / route with a query string, e.g., /?foo=bar. If i do this, that first if statement thats supposed to  replace "" with defaultKey, s3Key will be ?foo=bar and my defaultKey will not be used. The code continues and removes the query string from the s3Key making it s3Key = "". If my s3Key is passed to the s3Params as a blank string, which is passed to s3Request and finally when we call s3Request.createReadStream\(\), a 500 error is thrown by aws param_validator: UriParameterError: Expected uri parameter to have length >= 1, but found "" for params.Key. \n\n this fix removes the query string first since there is really nouse for it, to have the if that replaces "/" with defaultKey will work even if there is a query string.