### PR TITLE
Support range header to support partial downloads

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -14,9 +14,10 @@ var debug = require('debug')('s3-proxy');
 require('simple-errors');
 
 // HTTP headers from the AWS request to forward along
-var awsForwardHeaders = ['content-type', 'last-modified', 'etag', 'cache-control'];
+var awsForwardHeaders = ['content-type', 'last-modified', 'etag', 'cache-control',
+  'content-length', 'accept-ranges', 'content-range'];
 
-module.exports = function(options) {
+module.exports = function (options) {
   var s3 = new AWS.S3(assign(awsConfig(options),
     pick(options, 'endpoint', 's3ForcePathStyle')));
 
@@ -29,7 +30,7 @@ module.exports = function(options) {
     };
 
     debug('list s3 keys at', s3Params.Prefix);
-    s3.listObjects(s3Params, function(err, data) {
+    s3.listObjects(s3Params, function (err, data) {
       if (err) {
         return next(Error.create('Could not read S3 keys', {
           prefix: s3Params.prefix,
@@ -38,7 +39,7 @@ module.exports = function(options) {
       }
 
       var keys = [];
-      map(data.Contents, 'Key').forEach(function(key) {
+      map(data.Contents, 'Key').forEach(function (key) {
         // Chop off the prefix path
         if (key !== s3Params.Prefix) {
           if (isEmpty(s3Params.Prefix)) {
@@ -60,7 +61,7 @@ module.exports = function(options) {
     // If the key is empty (this occurs if a request comes in for a url ending in '/'), and there is a defaultKey
     // option present on options, use the default key
     // E.g. if someone wants to route '/' to '/index.html'
-    if ( s3Key === '' && options.defaultKey ) s3Key = options.defaultKey;
+    if (s3Key === '' && options.defaultKey) s3Key = options.defaultKey;
 
     // Chop off the querystring, it causes problems with SDK.
     var queryIndex = s3Key.indexOf('?');
@@ -70,13 +71,14 @@ module.exports = function(options) {
 
     // Strip out any path segments that start with a double dash '--'. This is just used
     // to force a cache invalidation.
-    s3Key = reject(s3Key.split('/'), function(segment) {
+    s3Key = reject(s3Key.split('/'), function (segment) {
       return segment.slice(0, 2) === '--';
     }).join('/');
 
     var s3Params = {
       Bucket: options.bucket,
-      Key: options.prefix ? urljoin(options.prefix, s3Key) : s3Key
+      Key: options.prefix ? urljoin(options.prefix, s3Key) : s3Key,
+      Range: req.headers['range'] || null,
     };
 
     debug('get s3 object with key %s', s3Params.Key);
@@ -92,15 +94,18 @@ module.exports = function(options) {
     var s3Request = s3.getObject(s3Params);
 
     // Write a custom http header with the path to the S3 object being proxied
-    var headerPrefix = req.app.settings.customHttpHeaderPrefix || 'x-4front-';
-    res.setHeader(headerPrefix + 's3-proxy-key', s3Params.Key);
+    if (options.proxyKey != false) {
+      var headerPrefix = req.app.settings.customHttpHeaderPrefix || 'x-4front-';
+      res.setHeader(headerPrefix + 's3-proxy-key', s3Params.Key);
+    }
 
-    s3Request.on('httpHeaders', function(statusCode, s3Headers) {
-      debug('received httpHeaders');
+    s3Request.on('httpHeaders', function (statusCode, s3Headers) {
+      debug('received httpHeaders', s3Headers);
 
       // Get the contentType from the headers
-      awsForwardHeaders.forEach(function(header) {
+      awsForwardHeaders.forEach(function (header) {
         var headerValue = s3Headers[header];
+        debug('got header from s3: ', header, headerValue);
 
         if (header === 'content-type') {
           if (headerValue === 'application/octet-stream') {
@@ -120,6 +125,7 @@ module.exports = function(options) {
           headerValue = '"' + trim(headerValue, '"') + '_base64' + '"';
         } else if (header === 'content-length' && base64Encode) {
           // Clear out the content-length if we are going to base64 encode the response
+          debug('clearing out content-length as base64Encode is enabled');
           headerValue = null;
         }
 
@@ -133,8 +139,8 @@ module.exports = function(options) {
     debug('read stream %s', s3Params.Key);
 
     var readStream = s3Request.createReadStream()
-      .on('error', function(err) {
-        debug('readStream error');
+      .on('error', function (err) {
+        debug('readStream error', err);
         // If the code is PreconditionFailed and we passed an IfNoneMatch param
         // the object has not changed, so just return a 304 Not Modified response.
         if (err.code === 'NotModified' ||
@@ -142,7 +148,7 @@ module.exports = function(options) {
           return res.status(304).end();
         }
         if (err.code === 'NoSuchKey') {
-          return next(Error.http(404, 'Missing S3 key', {code: 'missingS3Key', key: s3Params.Key}));
+          return next(Error.http(404, 'Missing S3 key', { code: 'missingS3Key', key: s3Params.Key }));
         }
         return next(err);
       });
@@ -156,7 +162,7 @@ module.exports = function(options) {
     readStream.pipe(res);
   }
 
-  return function(req, res, next) {
+  return function (req, res, next) {
     if (req.method !== 'GET') return next();
 
     //If a request is made to a url ending in '/', but there isn't a default file name,


### PR DESCRIPTION
Range header is important to support download resume and media
streaming. As [GetObject supports Range](1), this commit proxy the range
header from the request to Range parameter of the GetObject.

Also found some non-ascii filename caused header to be broken. Added
another option to suppress passing the proxied file path.

[1]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax